### PR TITLE
s/error/Error

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -196,7 +196,7 @@ class Builder {
         } else {
           range = [[row - 1, 0], [row - 1, 1000]]
         }
-        messages.push({name: linterName, type: 'error', row: row, column: column, text: text + ' (' + linterName + ')', filePath: file, range: range})
+        messages.push({name: linterName, type: 'Error', row: row, column: column, text: text + ' (' + linterName + ')', filePath: file, range: range})
       }
     }
     let match


### PR DESCRIPTION
This allows go build errors to actually show up in Atom as red errors rather than just warnings

![image](https://cloud.githubusercontent.com/assets/696842/16477194/7ea8cd0a-3e44-11e6-828e-e25e30e35ba3.png)
